### PR TITLE
ゲストログイン機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  ADMIN_USER_ID = 1
   GUEST_USER_ID = 2
 
   skip_before_action :verify_authenticity_token

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  GUEST_USER_ID = 2
+
   skip_before_action :verify_authenticity_token
 
   before_action :current_user

--- a/app/controllers/dokotomeyo/sessions_controller.rb
+++ b/app/controllers/dokotomeyo/sessions_controller.rb
@@ -8,6 +8,7 @@ class Dokotomeyo::SessionsController < ApplicationController
   before_action :forbid_login_user, {
     only: [
       :login,
+      :guest_login,
       :signup,
     ],
   }
@@ -30,6 +31,16 @@ class Dokotomeyo::SessionsController < ApplicationController
       render json: { status: 200, message: "ログインしました", name: @user.name }
     else
       render json: { status: 400, message: "メールアドレス もしくはパスワードが不正です" }
+    end
+  end
+
+  def guest_login
+    @user = User.find(GUEST_USER_ID)
+    if @user
+      session[:user_id] = @user.id
+      render json: { status: 200, message: "ログインしました", name: @user.name }
+    else
+      render json: { status: 400, message: "ログインに失敗しました" }
     end
   end
 

--- a/app/controllers/dokotomeyo/sessions_controller.rb
+++ b/app/controllers/dokotomeyo/sessions_controller.rb
@@ -51,10 +51,14 @@ class Dokotomeyo::SessionsController < ApplicationController
 
   def delete
     @user = User.find(session[:user_id])
-    InquiryMailer.send_delete(@user.id).deliver
-    @user.destroy
-    session[:user_id] = nil
-    render json: { status: 200, message: "退会しました" }
+    if @user.id == GUEST_USER_ID || @user.id == ADMIN_USER_ID
+      render json: { status: 400, message: "このアカウントの情報を編集することは許可されていません" }
+    else
+      InquiryMailer.send_delete(@user.id).deliver
+      @user.destroy
+      session[:user_id] = nil
+      render json: { status: 200, message: "退会しました" }
+    end
   end
 
   def issue_password

--- a/app/controllers/dokotomeyo/users_controller.rb
+++ b/app/controllers/dokotomeyo/users_controller.rb
@@ -29,7 +29,9 @@ class Dokotomeyo::UsersController < ApplicationController
 
   def update_name
     @user = User.find_by_id(session[:user_id])
-    if @user.update(update_name_params)
+    if @user.id == GUEST_USER_ID || @user.id == ADMIN_USER_ID
+      render json: { status: 400, message: "このアカウントの情報を編集することは許可されていません" }
+    elsif @user.update(update_name_params)
       render json: { status: 200, message: "変更しました" }
     else
       render json: { status: 400, message: @user.errors.full_messages }
@@ -38,7 +40,9 @@ class Dokotomeyo::UsersController < ApplicationController
 
   def update_email
     @user = User.find_by_id(session[:user_id])
-    if @user.update(update_email_params)
+    if @user.id == GUEST_USER_ID || @user.id == ADMIN_USER_ID
+      render json: { status: 400, message: "このアカウントの情報を編集することは許可されていません" }
+    elsif @user.update(update_email_params)
       render json: { status: 200, message: "変更しました" }
     else
       render json: { status: 400, message: @user.errors.full_messages }
@@ -47,7 +51,9 @@ class Dokotomeyo::UsersController < ApplicationController
 
   def update_password
     @user = User.find_by_id(session[:user_id])
-    if @user.authenticate(update_password_params[:currentPassword])
+    if @user.id == GUEST_USER_ID || @user.id == ADMIN_USER_ID
+      render json: { status: 400, message: "このアカウントの情報を編集することは許可されていません" }
+    elsif @user.authenticate(update_password_params[:currentPassword])
       if @user.update(password: update_password_params[:password], password_confirmation: update_password_params[:password_confirmation])
         render json: { status: 200, message: "変更しました" }
       else

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -9,6 +9,7 @@ import Top from "./Top/Top";
 import Mypage from "./Mypage/Mypage";
 import Post from "./Post/Post";
 import Login from "./Session/Login";
+import GuestLogin from "./Session/GuestLogin";
 import Signup from "./Session/Signup";
 import PostInquiry from "./PostInquiry/Inquiry";
 import DeleteUser from "./Session/DeleteUser";
@@ -32,6 +33,7 @@ const App = (props) => {
             <Route path="/dokotomeyo/mypage" element={<Mypage />} />
             <Route path="/dokotomeyo/post" element={<Post />} />
             <Route path="/dokotomeyo/login" element={<Login />} />
+            <Route path="/dokotomeyo/guest_login" element={<GuestLogin />} />
             <Route path="/dokotomeyo/signup" element={<Signup />} />
             <Route path="/dokotomeyo/post_inquiry" element={<PostInquiry />} />
             <Route path="/dokotomeyo/delete" element={<DeleteUser />} />

--- a/app/javascript/components/Session/DeleteUser.jsx
+++ b/app/javascript/components/Session/DeleteUser.jsx
@@ -15,9 +15,15 @@ const DeleteUser = () => {
   const handleSubmit = () => {
     axios.delete('/dokotomeyo/delete')
     .then((response) => {
-      setUserName();
       bookFlashMessage(response.data.message);
-      navigate("/dokotomeyo");
+      switch (response.data.status) {
+        case 200:
+          setUserName();
+          navigate("/dokotomeyo");
+          break;
+        case 400:
+          break;
+      }
     })
     .catch(() => {
       bookFlashMessage("通信に失敗しました");

--- a/app/javascript/components/Session/GuestLogin.jsx
+++ b/app/javascript/components/Session/GuestLogin.jsx
@@ -1,0 +1,110 @@
+import React, { useContext, useEffect, useState } from "react";
+import styled from 'styled-components';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+import FlashMessageContext from "../providers/FlashMessageProvider";
+import SessionContext from "../providers/SessionProvider";
+
+const GuestLogin = () => {
+  const [errors, setErrors] = useState([]);
+  const navigate = useNavigate();
+  const bookFlashMessage = useContext(FlashMessageContext);
+  const {userName, setUserName} = useContext(SessionContext);
+
+  const handleSubmit = () => {
+    axios.post('/dokotomeyo/guest_login')
+    .then((response) => {
+      switch (response.data.status){
+        case 200:
+          setUserName(response.data.name);
+          bookFlashMessage(response.data.message);
+          navigate("/dokotomeyo");
+          break;
+        case 400:
+          setErrors(response.data.message);
+          break;
+        case 401:
+          navigate("/dokotomeyo");
+          bookFlashMessage(response.data.message);
+          break;
+      }
+    })
+    .catch(() => {
+      setErrors(["通信に失敗しました"]);
+    })
+  }
+
+  useEffect(() => {
+    if (userName) {
+      bookFlashMessage("すでにログインしています");
+      navigate("/dokotomeyo");
+    }
+  }, []);
+
+  return (
+    <SForm_wrapper>
+      <SForm_title_container>
+        <SForm_title>ゲストログイン</SForm_title>
+        <SError_container>
+          {errors && <SError>{errors}</SError>}
+        </SError_container>
+      </SForm_title_container>
+      <SForm_container>
+        <li><p>ゲストでログインした場合、お気に入りやコメントは一定時間で削除されます。</p></li>
+        <SText_submit onClick={handleSubmit}>ログイン</SText_submit>
+      </SForm_container>
+    </SForm_wrapper>
+  );
+};
+
+const SForm_wrapper = styled.div`
+  background-color: rgb(255, 255, 255);
+`;
+
+const SForm_title_container = styled.div`
+  text-align: center;
+  padding: 30px;
+`;
+
+const SForm_title = styled.h1`
+  font-size: 25px;
+  padding: 5px;
+`;
+
+const SError_container = styled.ul`
+  font-size: 20px;
+  color: red;
+`;
+
+const SError = styled.p`
+  padding: 4px;
+`;
+
+const SText_submit = styled.button`
+  width: 20%;
+  background-color: rgb(75, 189, 255);
+  color: white;
+  border-radius: 4px;
+  margin: 10px;
+  margin-left: auto;
+  padding: 11px 20px;
+  text-align: center;
+`;
+
+const SForm_container = styled.ul`
+  background-color: rgb(235, 235, 235);
+  border-radius: 15px;
+  display: flex;
+  flex-direction: column;
+  width: 55%;
+  margin: 0 auto;
+  padding: 30px;
+  li {
+    margin: 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+`;
+
+export default GuestLogin;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     get    :post,                       to: "top#top"
     get    :signup,                     to: "top#top"
     get    :login,                      to: "top#top"
+    get    :guest_login,                to: "top#top"
     get    :delete,                     to: "top#top"
     get    :issue,                      to: "top#top"
     get    "/parking/:id",              to: "top#top"
@@ -16,6 +17,7 @@ Rails.application.routes.draw do
 
     post   :signup,                     to: 'sessions#signup'
     post   :login,                      to: 'sessions#login'
+    post   :guest_login,                to: 'sessions#guest_login'
     delete :logout,                     to: 'sessions#logout'
     delete :delete,                     to: 'sessions#delete'
     get    :issue_password,             to: 'sessions#issue_password'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,17 @@
 User.create(
+  id: 1,
   name: 'Administrator',
   email: ENV['ADMIN_EMAIL'],
   password: ENV['ADMIN_PASSWORD'],
   password_confirmation: ENV['ADMIN_PASSWORD'],
+  admin: true,
+)
+
+User.create(
+  id: 2,
+  name: 'ゲストユーザー',
+  email: ENV['GUEST_EMAIL'],
+  password: ENV['GUEST_PASSWORD'],
+  password_confirmation: ENV['GUEST_PASSWORD'],
   admin: true,
 )

--- a/lib/tasks/guest.rake
+++ b/lib/tasks/guest.rake
@@ -1,0 +1,13 @@
+namespace :guest do
+  desc "delete guest_user posts"
+  task reset_guest: :environment do
+    GUEST_USER_ID = 2
+    @user = User.find(GUEST_USER_ID)
+    @user.favorites.each do |favorite|
+      favorite.destroy
+    end
+    @user.comments.each do |comment|
+      comment.destroy
+    end
+  end
+end

--- a/spec/requests/sessions_controller/sessions_spec.rb
+++ b/spec/requests/sessions_controller/sessions_spec.rb
@@ -24,8 +24,9 @@ RSpec.describe "sessions", type: :request do
   end
 
   describe "POST" do
-    let!(:existing_user) { create(:user, name: "existing_user", email: "existing_user@gmail.com") }
+    let!(:admin_user) { create(:user, id: 1, name: "admin_user", email: "admin_user@gmail.com") }
     let!(:guest_user) { create(:user, id: 2, name: "guest_user", email: "guest_user@gmail.com") }
+    let!(:existing_user) { create(:user, id: 3, name: "existing_user", email: "existing_user@gmail.com") }
 
     describe "current_user is nil" do
       context "signup" do
@@ -134,6 +135,36 @@ RSpec.describe "sessions", type: :request do
           delete dokotomeyo_delete_path
           expect(JSON.parse(response.body)["status"]).to eq 200
           expect(session[:user_id]).to be nil
+        end
+      end
+    end
+
+    describe "current_user is admin" do
+      before do
+        post dokotomeyo_login_path, params: {
+          user: { email: guest_user.email, password: "password" },
+        }
+      end
+
+      context "delete" do
+        it "delete response is 400" do
+          delete dokotomeyo_delete_path
+          expect(JSON.parse(response.body)["status"]).to eq 400
+        end
+      end
+    end
+
+    describe "current_user is guest" do
+      before do
+        post dokotomeyo_login_path, params: {
+          user: { email: admin_user.email, password: "password" },
+        }
+      end
+
+      context "delete" do
+        it "delete response is 400" do
+          delete dokotomeyo_delete_path
+          expect(JSON.parse(response.body)["status"]).to eq 400
         end
       end
     end

--- a/spec/requests/sessions_controller/sessions_spec.rb
+++ b/spec/requests/sessions_controller/sessions_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "sessions", type: :request do
 
   describe "POST" do
     let!(:existing_user) { create(:user, name: "existing_user", email: "existing_user@gmail.com") }
+    let!(:guest_user) { create(:user, id: 2, name: "guest_user", email: "guest_user@gmail.com") }
 
     describe "current_user is nil" do
       context "signup" do
@@ -60,6 +61,14 @@ RSpec.describe "sessions", type: :request do
           }
           expect(JSON.parse(response.body)["status"]).to eq 400
           expect(session[:user_id]).to be nil
+        end
+      end
+
+      context "guest_login" do
+        it "guest_login response is 200" do
+          post dokotomeyo_guest_login_path
+          expect(JSON.parse(response.body)["status"]).to eq 200
+          expect(session[:user_id]).not_to be nil
         end
       end
 
@@ -101,6 +110,13 @@ RSpec.describe "sessions", type: :request do
           post dokotomeyo_login_path, params: {
             user: { email: existing_user.email, password: "password" },
           }
+          expect(JSON.parse(response.body)["status"]).to eq 401
+        end
+      end
+
+      context "guest_login" do
+        it "guest_login response is 401" do
+          post dokotomeyo_guest_login_path
           expect(JSON.parse(response.body)["status"]).to eq 401
         end
       end

--- a/spec/requests/top_controller/top_spec.rb
+++ b/spec/requests/top_controller/top_spec.rb
@@ -42,6 +42,27 @@ RSpec.describe "top", type: :request do
       end
     end
 
+    context "dokotomeyo_guest_login_path" do
+      it "guest_login response is 200" do
+        get dokotomeyo_guest_login_path
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "dokotomeyo_delete_path" do
+      it "delete response is 200" do
+        get dokotomeyo_delete_path
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "dokotomeyo_issue_path" do
+      it "issue response is 200" do
+        get dokotomeyo_issue_path
+        expect(response).to have_http_status(200)
+      end
+    end
+
     context "dokotomeyo/parking/:id path" do
       it "parking response is 200" do
         get "/dokotomeyo/parking/1"
@@ -52,6 +73,20 @@ RSpec.describe "top", type: :request do
     context "dokotomeyo/detail/:id path" do
       it "detail response is 200" do
         get "/dokotomeyo/detail/1"
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "dokotomeyo_admin_path" do
+      it "admin response is 200" do
+        get dokotomeyo_admin_path
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "dokotomeyo_post_inquiry_path" do
+      it "post_inquiry response is 200" do
+        get dokotomeyo_post_inquiry_path
         expect(response).to have_http_status(200)
       end
     end

--- a/spec/requests/users_controller/users_spec.rb
+++ b/spec/requests/users_controller/users_spec.rb
@@ -33,75 +33,165 @@ RSpec.describe "top", type: :request do
   end
 
   describe "POST" do
-    let!(:existing_user) { create(:user, name: "existing_user", email: "existing_user@gmail.com") }
+    let!(:admin_user) { create(:user, id: 1, name: "admin_user", email: "admin_user@gmail.com") }
+    let!(:guest_user) { create(:user, id: 2, name: "guest_user", email: "guest_user@gmail.com") }
+    let!(:existing_user) { create(:user, id: 3, name: "existing_user", email: "existing_user@gmail.com") }
 
-    before do
-      post dokotomeyo_login_path, params: {
-        user: { email: existing_user.email, password: "password" },
-      }
+    context "when admin_user" do
+      before do
+        post dokotomeyo_login_path, params: {
+          user: { email: admin_user.email, password: "password" },
+        }
+      end
+
+      context "update_name" do
+        it "update_name responce is 400" do
+          post dokotomeyo_update_name_path, params: {
+            user: {
+              name: "new_name",
+            },
+          }
+          expect(JSON.parse(response.body)["status"]).to eq 400
+        end
+      end
+
+      context "update_email" do
+        it "update_email responce is 400" do
+          post dokotomeyo_update_email_path, params: {
+            user: {
+              email: "new_mail@gmail.com",
+            },
+          }
+          expect(JSON.parse(response.body)["status"]).to eq 400
+        end
+      end
+
+      context "update_password" do
+        it "update_password responce is 400" do
+          post dokotomeyo_update_password_path, params: {
+            user: {
+              currentPassword: existing_user.password,
+              password: "new_password",
+              password_confirmation: "new_password",
+            },
+          }
+          expect(JSON.parse(response.body)["status"]).to eq 400
+        end
+      end
     end
 
-    context "update_name" do
-      it "update_name responce is 200 with name" do
-        post dokotomeyo_update_name_path, params: {
-          user: {
-            name: "new_name",
-          },
+    context "when guest_user" do
+      before do
+        post dokotomeyo_login_path, params: {
+          user: { email: guest_user.email, password: "password" },
         }
-        expect(JSON.parse(response.body)["status"]).to eq 200
       end
 
-      it "update_name responce is 400 without name" do
-        post dokotomeyo_update_name_path, params: {
-          user: {
-            name: "",
-          },
-        }
-        expect(JSON.parse(response.body)["status"]).to eq 400
+      context "update_name" do
+        it "update_name responce is 400" do
+          post dokotomeyo_update_name_path, params: {
+            user: {
+              name: "new_name",
+            },
+          }
+          expect(JSON.parse(response.body)["status"]).to eq 400
+        end
+      end
+
+      context "update_email" do
+        it "update_email responce is 400" do
+          post dokotomeyo_update_email_path, params: {
+            user: {
+              email: "new_mail@gmail.com",
+            },
+          }
+          expect(JSON.parse(response.body)["status"]).to eq 400
+        end
+      end
+
+      context "update_password" do
+        it "update_password responce is 400" do
+          post dokotomeyo_update_password_path, params: {
+            user: {
+              currentPassword: existing_user.password,
+              password: "new_password",
+              password_confirmation: "new_password",
+            },
+          }
+          expect(JSON.parse(response.body)["status"]).to eq 400
+        end
       end
     end
 
-    context "update_email" do
-      it "update_email responce is 200 with email" do
-        post dokotomeyo_update_email_path, params: {
-          user: {
-            email: "new_mail@gmail.com",
-          },
+    context "when existing_user" do
+      before do
+        post dokotomeyo_login_path, params: {
+          user: { email: existing_user.email, password: "password" },
         }
-        expect(JSON.parse(response.body)["status"]).to eq 200
       end
 
-      it "update_email responce is 400 without email" do
-        post dokotomeyo_update_email_path, params: {
-          user: {
-            email: "",
-          },
-        }
-        expect(JSON.parse(response.body)["status"]).to eq 400
-      end
-    end
+      context "update_name" do
+        it "update_name responce is 200 with name" do
+          post dokotomeyo_update_name_path, params: {
+            user: {
+              name: "new_name",
+            },
+          }
+          expect(JSON.parse(response.body)["status"]).to eq 200
+        end
 
-    context "update_password" do
-      it "update_password responce is 200" do
-        post dokotomeyo_update_password_path, params: {
-          user: {
-            currentPassword: existing_user.password,
-            password: "new_password",
-            password_confirmation: "new_password",
-          },
-        }
-        expect(JSON.parse(response.body)["status"]).to eq 200
+        it "update_name responce is 400 without name" do
+          post dokotomeyo_update_name_path, params: {
+            user: {
+              name: "",
+            },
+          }
+          expect(JSON.parse(response.body)["status"]).to eq 400
+        end
       end
 
-      it "update_password is 400" do
-        post dokotomeyo_update_password_path, params: {
-          user: {
-            currentPassword: existing_user.password,
-            password: "new_password",
-            password_confirmation: "new_passwordddd",
-          },
-        }
-        expect(JSON.parse(response.body)["status"]).to eq 400
+      context "update_email" do
+        it "update_email responce is 200 with email" do
+          post dokotomeyo_update_email_path, params: {
+            user: {
+              email: "new_mail@gmail.com",
+            },
+          }
+          expect(JSON.parse(response.body)["status"]).to eq 200
+        end
+
+        it "update_email responce is 400 without email" do
+          post dokotomeyo_update_email_path, params: {
+            user: {
+              email: "",
+            },
+          }
+          expect(JSON.parse(response.body)["status"]).to eq 400
+        end
+      end
+
+      context "update_password" do
+        it "update_password responce is 200" do
+          post dokotomeyo_update_password_path, params: {
+            user: {
+              currentPassword: existing_user.password,
+              password: "new_password",
+              password_confirmation: "new_password",
+            },
+          }
+          expect(JSON.parse(response.body)["status"]).to eq 200
+        end
+
+        it "update_password is 400" do
+          post dokotomeyo_update_password_path, params: {
+            user: {
+              currentPassword: existing_user.password,
+              password: "new_password",
+              password_confirmation: "new_passwordddd",
+            },
+          }
+          expect(JSON.parse(response.body)["status"]).to eq 400
+        end
       end
     end
   end


### PR DESCRIPTION
ゲスト用のログイン機能の実装

ゲストログインページからログインすると、あらかじめ用意されたゲスト用アカウントでログインできる。
あくまでdokotomeyoのお試しをするためのものなので、投稿コメントやお気に入りは削除される。

_ゲストログイン用のページの実装_
_ゲスト用アカウントでのログイン処理_
_10分毎にゲストユーザーと紐付いたcomments、favoritesの削除_
_管理者ユーザー、ゲストユーザーのユーザー情報編集、退会処理をさせない_